### PR TITLE
1.3.0 - fee-recovery-for-givewp (Correção de compatibilidade com o formulário legado e o 3.0+) 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,16 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    # Run composer install and generate vendor
-    - name: Run composer install
-      uses: php-actions/composer@v6
-      with:
-        php_version: ${{ env.PHP_VERSION }}
-        working_dir: "."
-        args: --ignore-platform-reqs
-        command: install
-        dev: no
-
     - name: Executar Plugin Check com configurações personalizadas
       uses: wordpress/plugin-check-action@v1
       with:
@@ -55,7 +45,6 @@ jobs:
         mkdir -p dist
         mkdir -p build/${{ env.PLUGIN_NAME }}
         mv ./admin ./includes ./languages ./public *.php *.txt ./build/${{ env.PLUGIN_NAME }}
-        cp -r vendor build/${{ env.PLUGIN_NAME }}/vendor
         find ./build -type f -exec chmod 0644 {} +
         find ./build -type d -exec chmod 0755 {} +
 

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -17,20 +17,10 @@ jobs:
         with:
           ref: main
 
-      - name: Run composer install
-        uses: php-actions/composer@v6
-        with:
-          php_version: ${{ env.PHP_VERSION }}
-          working_dir: "."
-          args: --ignore-platform-reqs
-          command: install
-          dev: no
-
       - name: Prepare plugin folder
         run: |
           mkdir -p build/${{ env.PLUGIN_NAME }}
           mv ./admin ./includes ./languages ./public *.php *.txt ./build/${{ env.PLUGIN_NAME }}
-          cp -r vendor build/${{ env.PLUGIN_NAME }}/vendor
           find ./build -type f -exec chmod 0644 {} +
           find ./build -type d -exec chmod 0755 {} +
 


### PR DESCRIPTION
# Fee recovery for GiveWP

* Contribuidores: LinkNacional
* Link para doações: [LinkNacional](https://www.linknacional.com.br/)
* Tags: fee, donation, givewp, form, recover
* Testado até: 6.7
* Requer PHP: 7.4
* Tag estável: 1.3.0
* Licença: GPLv2 ou posterior
* URI da licença: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
* Traduções: Português(Brasil)

## Descrição

O plugin [Recuperação de Taxas para GiveWP](https://www.linknacional.com/wordpress/) 
oferece aos doadores a opção de cobrir as taxas de pagamento associadas às suas doações 
realizadas por meio de um formulário no site. 

## Como instalar?

1. Acesse o painel de administração do WordPress e vá para **Plugins > Adicionar Novo**.
2. Pesquise por "Calculadora de frete melhorada para lojas brasileiras".
3. Encontre o plugin, clique em **Instalar Agora** e depois em **Ativar**.
4. Pronto! Nenhuma configuração adicional é necessária.

## Resumo(1.3.0):

> Correção de compatibilidade com o formulário legado e o 3.0+ 

![image](https://github.com/user-attachments/assets/c3c0840b-8f0d-462d-b824-d7236bb4d169)

![image](https://github.com/user-attachments/assets/98b6a702-d6a6-42aa-b6b9-37ebb5d42545)